### PR TITLE
Check for milliampere output

### DIFF
--- a/app/src/main/java/dubrowgn/wattz/Battery.kt
+++ b/app/src/main/java/dubrowgn/wattz/Battery.kt
@@ -33,6 +33,8 @@ class Battery(ctx: Context) {
     }
 
     private fun fromMillis(v: Double?) : Double? {
+        if (v?.compareTo(5.0) < 0)
+            return v
         return v?.div(1_000.0)
     }
 


### PR DESCRIPTION
Added a check for whether the "milliampere" are actual milliampere or already ampere under the assumption that the amperage will never be above 5A. I don't know how Kotlin works so this code might not even compile, sorry. But this is my general idea.