### PR TITLE
Average wattage draw

### DIFF
--- a/app/src/main/java/dubrowgn/wattz/Battery.kt
+++ b/app/src/main/java/dubrowgn/wattz/Battery.kt
@@ -86,7 +86,7 @@ class Battery(ctx: Context) {
         return fromMillis(secs.toDouble())
     }
 
-    // average battery watts draw since last charge
+    // average battery wattage draw since last charge or phone last start-up
     private var totalWatts:Double = 0.0
     private var counter = 0
 
@@ -99,7 +99,7 @@ class Battery(ctx: Context) {
         } else {
             totalWatts = 0.0
             counter = 0
-            
+
             0.0
         }
     }

--- a/app/src/main/java/dubrowgn/wattz/Battery.kt
+++ b/app/src/main/java/dubrowgn/wattz/Battery.kt
@@ -85,4 +85,22 @@ class Battery(ctx: Context) {
 
         return fromMillis(secs.toDouble())
     }
+
+    // average battery watts draw since last charge
+    private var totalWatts:Double = 0.0
+    private var counter = 0
+
+    fun calculateAvgWatts(): Double {
+        return if (!charging){
+            totalWatts += watts!!
+            counter++
+
+            totalWatts/counter
+        } else {
+            totalWatts = 0.0
+            counter = 0
+            
+            0.0
+        }
+    }
 }

--- a/app/src/main/java/dubrowgn/wattz/StatusService.kt
+++ b/app/src/main/java/dubrowgn/wattz/StatusService.kt
@@ -98,7 +98,7 @@ class StatusService : Service() {
 
         startForeground(noteId, noteBuilder.build())
 
-        return START_STICKY;
+        return START_STICKY
     }
 
     override fun onDestroy() {
@@ -129,13 +129,16 @@ class StatusService : Service() {
         return Icon.createWithBitmap(bitmap)
     }
 
+
+
     private fun update() {
         debug("update()")
 
         val txtWatts = fmt(battery.watts)
+        val txtAvgWatts = fmt(battery.calculateAvgWatts())
 
         noteBuilder
-            .setContentTitle("Battery Draw: $txtWatts W")
+            .setContentTitle("Battery Draw: $txtWatts W\nAvg. Draw: $txtAvgWatts")
             .setSmallIcon(renderIcon(txtWatts, "w"))
 
         noteBuilder.setContentText(


### PR DESCRIPTION
Feature update for average wattage draw calculation since last phone start-up or charging or since last app start. Implemented only for push-notification area. Possible to retrofit for main activity window if needed.